### PR TITLE
feat(transfer): add tests for transfer in/out

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ export const config = yargs
     demandOption: true,
     example: 'quoteInNigeriaCUSD',
     options: Object.keys(MOCK_QUOTE),
+    default: "",
   })
   .option('quote-out-mock', {
     description:

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,14 @@ export const config = yargs
     type: 'string',
     demandOption: false,
   })
+  .option('quote-in-mock', {
+    description:
+      'Mock data to use for a transfer in quote that should be offered',
+    type: 'string',
+    demandOption: true,
+    example: 'quoteInNigeriaCUSD',
+    options: Object.keys(MOCK_QUOTE),
+  })
   .option('quote-out-mock', {
     description:
       'Mock data to use for a transfer out quote that should be offered',

--- a/src/mock-data/quote.ts
+++ b/src/mock-data/quote.ts
@@ -11,6 +11,14 @@ const quoteOutNigeriaCUSD: QuoteRequestBody = {
   country: 'NG',
 }
 
+const quoteInNigeriaCUSD: QuoteRequestBody = {
+  cryptoType: CryptoType.cUSD,
+  fiatType: FiatType.NGN,
+  cryptoAmount: '.01',
+  country: 'NG',
+}
+
 export const MOCK_QUOTE: Record<string, QuoteRequestBody> = {
+  quoteInNigeriaCUSD,
   quoteOutNigeriaCUSD,
 }

--- a/validations/transfer.test.ts
+++ b/validations/transfer.test.ts
@@ -1,0 +1,136 @@
+import { expect, use } from 'chai'
+import { Wallet, ethers } from 'ethers'
+import path from 'path'
+import { randomUUID } from 'crypto'
+import { AddKycParams, FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
+import {
+  KycSchema,
+  TransferStatus,
+  Network,
+} from '@fiatconnect/fiatconnect-types'
+import { config } from '../src/config'
+import { chaiPlugin } from 'api-contract-validator'
+import { MOCK_QUOTE } from '../src/mock-data/quote'
+import { MOCK_KYC } from '../src/mock-data/kyc'
+import { MOCK_FIAT_ACCOUNTS } from '../src/mock-data/fiat-account'
+
+const apiDefinitionsPath = path.join(config.openapiSpec)
+use(chaiPlugin({ apiDefinitionsPath }))
+
+describe('/transfer', () => {
+  const mockAccountData =
+    MOCK_FIAT_ACCOUNTS[
+    config.fiatAccountMock as keyof typeof MOCK_FIAT_ACCOUNTS
+  ]
+
+  const mockKYCInfo: AddKycParams<KycSchema> =
+    MOCK_KYC[config.kycMock as keyof typeof MOCK_KYC]
+
+  describe('/in', () => {
+    const wallet = Wallet.createRandom()
+
+    const fiatConnectClient = new FiatConnectClient(
+      {
+        baseUrl: config.baseUrl,
+        network: Network.Alfajores,
+        accountAddress: wallet.address,
+      },
+      (message: string) => wallet.signMessage(message),
+    )
+
+    const quoteInParams = {
+      ...MOCK_QUOTE[config.quoteInMock],
+      address: wallet.address,
+    }
+
+    it('able to transfer fiat in for crypto', async () => {
+      const loginResult = await fiatConnectClient.login()
+      expect(loginResult.isOk).to.be.ok
+
+      const quoteInResponse = await fiatConnectClient.createQuoteIn(
+        quoteInParams,
+      )
+      expect(quoteInResponse.isOk).to.be.ok
+      const quoteId = quoteInResponse.unwrap().quote.quoteId
+
+      const addKycResult = await fiatConnectClient.addKyc(mockKYCInfo)
+      expect(addKycResult.isOk).to.be.true
+
+      const addAccountResult = await fiatConnectClient.addFiatAccount(
+        mockAccountData,
+      )
+      expect(addAccountResult.isOk).to.be.true
+      const fiatAccountId = addAccountResult.unwrap().fiatAccountId
+
+      const transferInParams = {
+        idempotencyKey: randomUUID(),
+        data: {
+          fiatAccountId: fiatAccountId,
+          quoteId: quoteId,
+        },
+      }
+
+      const transferInResponse = await fiatConnectClient.transferIn(
+        transferInParams,
+      )
+      expect(transferInResponse.isOk).to.be.ok
+      expect(transferInResponse.unwrap().transferStatus).to.be.oneOf(
+        Object.values(TransferStatus),
+      )
+    })
+  })
+
+  describe('/out', () => {
+    const wallet = new ethers.Wallet(config.testPrivateKey)
+
+    const fiatConnectClient = new FiatConnectClient(
+      {
+        baseUrl: config.baseUrl,
+        network: Network.Alfajores,
+        accountAddress: wallet.address,
+      },
+      (message: string) => wallet.signMessage(message),
+    )
+
+    const quoteOutParams = {
+      ...MOCK_QUOTE[config.quoteOutMock],
+      address: wallet.address,
+    }
+
+    it('able to transfer crypto in for fiat out', async () => {
+      const loginResult = await fiatConnectClient.login()
+      expect(loginResult.isOk).to.be.ok
+
+      const addKycResult = await fiatConnectClient.addKyc(mockKYCInfo)
+      expect(addKycResult.isOk).to.be.true
+
+      const addAccountResult = await fiatConnectClient.addFiatAccount(
+        mockAccountData,
+      )
+      expect(addAccountResult.isOk).to.be.true
+      const fiatAccountId = addAccountResult.unwrap().fiatAccountId
+
+      const quoteOutResponse = await fiatConnectClient.createQuoteOut(
+        quoteOutParams,
+      )
+      expect(quoteOutResponse.isOk).to.be.ok
+      const quoteOutId = quoteOutResponse.unwrap().quote.quoteId
+
+      const transferOutParams = {
+        idempotencyKey: randomUUID(),
+        data: {
+          fiatAccountId: fiatAccountId,
+          quoteId: quoteOutId,
+        },
+      }
+
+      const transferOutResponse = await fiatConnectClient.transferOut(
+        transferOutParams,
+      )
+      expect(transferOutResponse.isOk).to.be.ok
+      expect(transferOutResponse.unwrap().transferStatus).to.be.oneOf(
+        Object.values(TransferStatus),
+      )
+    })
+  })
+})


### PR DESCRIPTION
Adds initial happy path test for transfer in/out. The test does not yet verify that the transfer status eventually reaches complete or failed, nor is crypto sent from the test wallet when transferring out.