### PR TITLE
feat(checks): Add swagger validation for API calls made using the SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dotenv": "^16.0.0",
     "ethers": "^5.6.8",
     "jest": "^28.1.3",
+    "swagger-object-validator": "^1.4.5",
     "ts-jest": "^28.0.7",
     "yargs": "^17.4.1"
   }

--- a/src/check-response-schema.ts
+++ b/src/check-response-schema.ts
@@ -3,8 +3,10 @@ import { config } from './config'
 import { expect, use } from 'chai'
 import { chaiPlugin } from 'api-contract-validator'
 import { AxiosResponse } from 'axios'
+import * as SwaggerValidator from 'swagger-object-validator'
 
 const apiDefinitionsPath = path.join(config.openapiSpec)
+const validator = new SwaggerValidator.Handler(config.openapiSpec)
 use(chaiPlugin({ apiDefinitionsPath }))
 
 /**
@@ -19,4 +21,14 @@ export function checkResponseSchema(response: AxiosResponse) {
     response.request.path = response.request.path.slice(versionPrefixMatch[0].length)
   }
   expect(response).to.matchApiSchema()
+}
+
+/**
+ * Directly checks that an object matches an OpenAPI Model. We need to use this when checking results
+ * from the SDK, since intercepting the network calls directly yields response objects that are incompitable
+ * with those required by the Chai plugin matcher.
+ */
+export async function checkObjectAgainstModel(data: any, model: string) {
+  const result = await validator.validateModel(data, model)
+  expect(result.errors.length).to.equal(0, result!.humanReadable() as string)
 }

--- a/validations/accounts.test.ts
+++ b/validations/accounts.test.ts
@@ -6,6 +6,8 @@ import { FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
 import path from 'path'
 import { chaiPlugin } from 'api-contract-validator'
 import { MOCK_FIAT_ACCOUNTS } from '../src/mock-data/fiat-account'
+import { checkObjectAgainstModel } from '../src/check-response-schema'
+
 
 const apiDefinitionsPath = path.join(config.openapiSpec)
 use(chaiPlugin({ apiDefinitionsPath }))
@@ -33,6 +35,7 @@ describe('accounts', () => {
     const getAccountsResult = await fiatConnectClient.getFiatAccounts()
     expect(getAccountsResult.isOk).to.be.true
     expect(!!getAccountsResult.unwrap().BankAccount?.length).to.be.false
+    await checkObjectAgainstModel(getAccountsResult.unwrap(), 'GetFiatAccountsResponse')
   })
   it('able to post and get', async () => {
     const wallet = ethers.Wallet.createRandom()
@@ -52,9 +55,12 @@ describe('accounts', () => {
       mockAccountData,
     )
     expect(addAccountResult.isOk).to.be.true
+    await checkObjectAgainstModel(addAccountResult.unwrap(), 'FiatAccountInfoResponse')
 
     const getAccountsResult = await fiatConnectClient.getFiatAccounts()
     expect(getAccountsResult.isOk).to.be.true
+    await checkObjectAgainstModel(getAccountsResult.unwrap(), 'GetFiatAccountsResponse')
+
     expect(getAccountsResult.unwrap().BankAccount?.length).to.be.gt(0)
   })
   // TODO test DELETE /accounts/:fiatAccountId (once a working POST endpoint exists...)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,6 +1113,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bluebird@^3.5.36":
+  version "3.5.36"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.36.tgz#00d9301d4dc35c2f6465a8aec634bb533674c652"
+  integrity sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==
+
 "@types/chai@^4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
@@ -1184,6 +1189,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/swagger-schema-official@<2.0.18":
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/@types/swagger-schema-official/-/swagger-schema-official-2.0.17.tgz#c9086ec36ce00ae21e5a73a507c8fc94938f17e1"
+  integrity sha512-+lvLQ9GHI49zzXMNABVbsyCYXFdflW5IMUM/hgqEEholSyUwdsovwTohx2kQIDrhJOUAZjskOHbeWPy/xbAdqA==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -1573,6 +1583,11 @@ bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
+bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bn.js@^4.11.9:
   version "4.12.0"
@@ -3330,7 +3345,7 @@ js-yaml@^3.13.1, js-yaml@^3.14.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0:
+js-yaml@^4.0.5, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -4221,6 +4236,16 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+swagger-object-validator@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/swagger-object-validator/-/swagger-object-validator-1.4.5.tgz#51cbdff71974f49c07b3cadaabb177e3fb02da5e"
+  integrity sha512-O5Q1T2nFqSDIUFj9YXv8vZ2Ih5oVEiVTx/MXbp4NiycEM+Twsn0G5Wl/gahsEDSsh5PhHVIl5g+Sy6yXOCi3pg==
+  dependencies:
+    "@types/bluebird" "^3.5.36"
+    "@types/swagger-schema-official" "<2.0.18"
+    bluebird "^3.7.2"
+    js-yaml "^4.0.5"
 
 swagger-parser@^10.0.3:
   version "10.0.3"


### PR DESCRIPTION
This isn't very pretty, but previously, we didn't have a way to meaningfully and automatically check the shape of data returned from API calls made using the SDK.

I tried spying on the global `fetch` object to pull out the `Response` objects it generated, but unfortunately, they are a different shape than the ones required by our swagger validation plugin (`AxiosResponse`). I even tried manually constructing `Partial<AxiosResponse>` objects from the raw `Response`... with pretty poor results, so just settled with this. The output is less pretty, but it works.