### PR TITLE
feat(accounts): Add test for duplicate accounts among different addresses

### DIFF
--- a/validations/accounts.test.ts
+++ b/validations/accounts.test.ts
@@ -71,7 +71,7 @@ describe('accounts', () => {
       {
         baseUrl: config.baseUrl,
         network: Network.Alfajores,
-        accountAddress: wallet.address,
+        accountAddress: wallet2.address,
         apiKey: config.clientApiKey,
       },
       (message: string) => wallet2.signMessage(message),

--- a/validations/accounts.test.ts
+++ b/validations/accounts.test.ts
@@ -58,9 +58,6 @@ describe('accounts', () => {
     const addAccountResult = await fiatConnectClient.addFiatAccount(
       mockAccountData,
     )
-    if (addAccountResult.isErr) {
-      console.log(addAccountResult.error)
-    }
     expect(addAccountResult.isOk).to.be.true
     await checkObjectAgainstModel(
       addAccountResult.unwrap(),

--- a/validations/accounts.test.ts
+++ b/validations/accounts.test.ts
@@ -58,35 +58,12 @@ describe('accounts', () => {
     const addAccountResult = await fiatConnectClient.addFiatAccount(
       mockAccountData,
     )
+    if (addAccountResult.isErr) {
+      console.log(addAccountResult.error)
+    }
     expect(addAccountResult.isOk).to.be.true
     await checkObjectAgainstModel(
       addAccountResult.unwrap(),
-      'FiatAccountInfoResponse',
-    )
-
-    // Another address should be able to add the same exact account
-    // without a collision
-    const wallet2 = ethers.Wallet.createRandom()
-    const fiatConnectClient2 = new FiatConnectClient(
-      {
-        baseUrl: config.baseUrl,
-        network: Network.Alfajores,
-        accountAddress: wallet2.address,
-        apiKey: config.clientApiKey,
-      },
-      (message: string) => wallet2.signMessage(message),
-    )
-    const loginResult2 = await fiatConnectClient2.login()
-    expect(loginResult2.isOk).to.be.ok
-
-    // Add the same account to the new address and verify response
-    const addAccountResult2 = await fiatConnectClient2.addFiatAccount(
-      mockAccountData,
-    )
-    expect(addAccountResult2.isOk).to.be.true
-
-    await checkObjectAgainstModel(
-      addAccountResult2.unwrap(),
       'FiatAccountInfoResponse',
     )
 
@@ -121,5 +98,54 @@ describe('accounts', () => {
         FiatConnectError.ResourceNotFound,
       )
     }
+  })
+  it('able to add same account to multiple addresses', async () => {
+    const wallet = ethers.Wallet.createRandom()
+    const fiatConnectClient = new FiatConnectClient(
+      {
+        baseUrl: config.baseUrl,
+        network: Network.Alfajores,
+        accountAddress: wallet.address,
+        apiKey: config.clientApiKey,
+      },
+      (message: string) => wallet.signMessage(message),
+    )
+    const loginResult = await fiatConnectClient.login()
+    expect(loginResult.isOk).to.be.ok
+
+    // Add an account and verify response
+    const addAccountResult = await fiatConnectClient.addFiatAccount(
+      mockAccountData,
+    )
+    expect(addAccountResult.isOk).to.be.ok
+    await checkObjectAgainstModel(
+      addAccountResult.unwrap(),
+      'FiatAccountInfoResponse',
+    )
+
+    // Another address should be able to add the same exact account
+    // without a collision
+    const wallet2 = ethers.Wallet.createRandom()
+    const fiatConnectClient2 = new FiatConnectClient(
+      {
+        baseUrl: config.baseUrl,
+        network: Network.Alfajores,
+        accountAddress: wallet2.address,
+        apiKey: config.clientApiKey,
+      },
+      (message: string) => wallet2.signMessage(message),
+    )
+    const loginResult2 = await fiatConnectClient2.login()
+    expect(loginResult2.isOk).to.be.true
+
+    // Add the same account to the new address and verify response
+    const addAccountResult2 = await fiatConnectClient2.addFiatAccount(
+      mockAccountData,
+    )
+    expect(addAccountResult2.isOk).to.be.ok
+    await checkObjectAgainstModel(
+      addAccountResult2.unwrap(),
+      'FiatAccountInfoResponse',
+    )
   })
 })

--- a/validations/accounts.test.ts
+++ b/validations/accounts.test.ts
@@ -64,6 +64,32 @@ describe('accounts', () => {
       'FiatAccountInfoResponse',
     )
 
+    // Another address should be able to add the same exact account
+    // without a collision
+    const wallet2 = ethers.Wallet.createRandom()
+    const fiatConnectClient2 = new FiatConnectClient(
+      {
+        baseUrl: config.baseUrl,
+        network: Network.Alfajores,
+        accountAddress: wallet.address,
+        apiKey: config.clientApiKey,
+      },
+      (message: string) => wallet2.signMessage(message),
+    )
+    const loginResult2 = await fiatConnectClient2.login()
+    expect(loginResult2.isOk).to.be.ok
+
+    // Add the same account to the new address and verify response
+    const addAccountResult2 = await fiatConnectClient2.addFiatAccount(
+      mockAccountData,
+    )
+    expect(addAccountResult2.isOk).to.be.true
+
+    await checkObjectAgainstModel(
+      addAccountResult.unwrap(),
+      'FiatAccountInfoResponse',
+    )
+
     // Get account and verify that added account is there
     const getAccountsResult = await fiatConnectClient.getFiatAccounts()
     expect(getAccountsResult.isOk).to.be.true

--- a/validations/accounts.test.ts
+++ b/validations/accounts.test.ts
@@ -86,7 +86,7 @@ describe('accounts', () => {
     expect(addAccountResult2.isOk).to.be.true
 
     await checkObjectAgainstModel(
-      addAccountResult.unwrap(),
+      addAccountResult2.unwrap(),
       'FiatAccountInfoResponse',
     )
 


### PR DESCRIPTION
Adds a new check to the accounts validation, in particular, to catch an issue that was appearing (but not being tested for!) in Bitssa's API, where:

* Address A adds a fiat account with some specific details
* Address B adds a fiat account with the _same_ details
  * This attempt to add the account fails with a `ResourceExists` error

Fiat Accounts should not be globally unique, since this introduces the possibility of leaking data about what accounts have been previously linked to other addresses (it also prevents users with multiple blockchain addresses from linking the same account). Fiat accounts need only be unique _per account address_; this check validates that.