### PR TITLE
chore(timeout): update testTimeout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,5 @@ module.exports = {
       tsconfig: 'tsconfig.json',
     },
   },
+  testTimeout: 10000,
 }


### PR DESCRIPTION
Valora's own sandbox environment was failing here, and in general, we don't expect sandbox environments to be heavily resourced. I suggest we increase the timeout to 10s and keep the focus on correctness rather than performance