### PR TITLE
feat(zod): check response schemas with zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "jest": "^28.1.3",
     "swagger-object-validator": "^1.4.5",
     "ts-jest": "^28.0.8",
-    "yargs": "^17.4.1"
+    "yargs": "^17.4.1",
+    "zod": "^3.19.1"
   }
 }

--- a/validations/clock.test.ts
+++ b/validations/clock.test.ts
@@ -5,6 +5,7 @@ import { FIFTEEN_MINUTES_IN_MS } from '../src/constants'
 import path from 'path'
 import { chaiPlugin } from 'api-contract-validator'
 import { checkResponseSchema } from '../src/check-response-schema'
+import { clockResponseSchema } from '@fiatconnect/fiatconnect-types'
 
 const apiDefinitionsPath = path.join(config.openapiSpec)
 use(chaiPlugin({ apiDefinitionsPath }))
@@ -17,7 +18,7 @@ describe('/clock', () => {
     })
     const response = await client.get(`/clock`)
     expect(response).to.have.status(200)
-    checkResponseSchema(response)
+    checkResponseSchema(response, clockResponseSchema)
     const serverTimeStr = response.data?.time
     expect(!!serverTimeStr).to.be.true
     const serverTime = new Date(serverTimeStr)

--- a/validations/quote.test.ts
+++ b/validations/quote.test.ts
@@ -7,6 +7,7 @@ import { config } from '../src/config'
 import { checkResponseSchema } from '../src/check-response-schema'
 import { MOCK_QUOTE } from '../src/mock-data/quote'
 import { ethers } from 'ethers'
+import { quoteResponseSchema } from '@fiatconnect/fiatconnect-types'
 
 const apiDefinitionsPath = path.join(config.openapiSpec)
 use(chaiPlugin({ apiDefinitionsPath }))
@@ -31,7 +32,7 @@ describe('/quote', () => {
       const response = await client.post(`/quote/out`, quoteParams)
       expect(response).to.have.status(200)
       expect(response.data.quote.quoteId).not.to.be.equal('')
-      checkResponseSchema(response)
+      checkResponseSchema(response, quoteResponseSchema)
     })
     it('Doesnt support quotes for unreasonably large transfer out', async () => {
       const client = axios.create({


### PR DESCRIPTION
Bitmama's API was passing quote tests, but gave a FiatAccountType where it should have had a FiatAccountSchema, and numbers where it needed strings. This change adds regression coverage for those bugs.