### PR TITLE
chore: setup job for periodically running tests against mock-provider

### DIFF
--- a/.github/workflows/validate-mock-provider.yaml
+++ b/.github/workflows/validate-mock-provider.yaml
@@ -40,3 +40,14 @@ jobs:
           args: -o specification-swagger.yaml https://raw.githubusercontent.com/fiatconnect/specification/main/swagger.yaml
       - run: yarn
       - run: yarn validate
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notification_title: '{workflow} has {status_message}'
+          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
+          footer: 'Linked Repo <{repo_url}|{repo}>'
+          mention_groups: 'S02G1BH7D08'
+          mention_groups_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/validate-mock-provider.yaml
+++ b/.github/workflows/validate-mock-provider.yaml
@@ -6,22 +6,15 @@ on:
   # Cron schedule for every weekday at 4 PM GMT
   schedule:
     - cron: '0 16 * * 1-5'
+  # Whenever this file is updated
   push:
-    branches:
-      - 'satish/validate-job'
+    paths:
+      - '.github/workflows/validate-mock-provider.yml'
 
 jobs:
   validate:
     name: Validate mock-provider
     runs-on: ubuntu-latest
-    env:
-      BASE_URL: ${{ secrets.MOCK_PROVIDER_BASE_URL }}
-      CLIENT_API_KEY: ${{ secrets.MOCK_PROVIDER_API_KEY }}
-      PROVIDER_ID: ${{ secrets.MOCK_PROVIDER_ID }}
-      OPENAPI_SPEC: specification-swagger.yaml
-      QUOTE_OUT_MOCK: quoteOutNigeriaCUSD
-      FIAT_ACCOUNT_MOCK: accountNumberNigeria
-      KYC_MOCK: personalDataAndDocumentsNigeria
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -40,7 +33,14 @@ jobs:
           args: -o specification-swagger.yaml https://raw.githubusercontent.com/fiatconnect/specification/main/swagger.yaml
       - run: yarn
       - run: yarn validate
-      - run: exit 1
+        env:
+          BASE_URL: ${{ secrets.MOCK_PROVIDER_BASE_URL }}
+          CLIENT_API_KEY: ${{ secrets.MOCK_PROVIDER_API_KEY }}
+          PROVIDER_ID: ${{ secrets.MOCK_PROVIDER_ID }}
+          OPENAPI_SPEC: specification-swagger.yaml
+          QUOTE_OUT_MOCK: quoteOutNigeriaCUSD
+          FIAT_ACCOUNT_MOCK: accountNumberNigeria
+          KYC_MOCK: personalDataAndDocumentsNigeria
       - uses: ravsamhq/notify-slack-action@v2
         if: always()
         with:
@@ -49,6 +49,7 @@ jobs:
           message_format: '{emoji} *{workflow}* {status_message}. <{run_url}|View Run>'
           footer: 'Repo: <{repo_url}|{repo}>'
           notify_when: 'failure'
+          # Tag @eng-activation on failures
           mention_groups: 'S02G1BH7D08'
           mention_groups_when: 'failure'
         env:

--- a/.github/workflows/validate-mock-provider.yaml
+++ b/.github/workflows/validate-mock-provider.yaml
@@ -1,0 +1,39 @@
+name: Validate mock-provider
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Cron schedule for every weekday at 4 PM GMT
+  schedule:
+    - cron: '0 16 * * 1-5'
+
+jobs:
+  validate:
+    name: Validate mock-provider
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ secrets.MOCK_PROVIDER_BASE_URL }}
+      CLIENT_API_KEY: ${{ secrets.MOCK_PROVIDER_API_KEY }}
+      PROVIDER_ID: ${{ secrets.MOCK_PROVIDER_ID }}
+      OPENAPI_SPEC: specification-swagger.yaml
+      QUOTE_OUT_MOCK: quoteOutNigeriaCUSD
+      FIAT_ACCOUNT_MOCK: accountNumberNigeria
+      KYC_MOCK: personalDataAndDocumentsNigeria
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          check-latest: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Get specification swagger
+        uses: wei/curl@v1
+        with:
+          args: -o specification-swagger.yaml https://raw.githubusercontent.com/fiatconnect/specification/main/swagger.yaml
+      - run: yarn
+      - run: yarn validate

--- a/.github/workflows/validate-mock-provider.yaml
+++ b/.github/workflows/validate-mock-provider.yaml
@@ -40,13 +40,15 @@ jobs:
           args: -o specification-swagger.yaml https://raw.githubusercontent.com/fiatconnect/specification/main/swagger.yaml
       - run: yarn
       - run: yarn validate
+      - run: exit 1
       - uses: ravsamhq/notify-slack-action@v2
         if: always()
         with:
           status: ${{ job.status }}
           notification_title: '{workflow} has {status_message}'
-          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
-          footer: 'Linked Repo <{repo_url}|{repo}>'
+          message_format: '{emoji} *{workflow}* {status_message}. <{run_url}|View Run>'
+          footer: 'Repo: <{repo_url}|{repo}>'
+          notify_when: 'failure'
           mention_groups: 'S02G1BH7D08'
           mention_groups_when: 'failure'
         env:

--- a/.github/workflows/validate-mock-provider.yaml
+++ b/.github/workflows/validate-mock-provider.yaml
@@ -23,12 +23,12 @@ jobs:
       FIAT_ACCOUNT_MOCK: accountNumberNigeria
       KYC_MOCK: personalDataAndDocumentsNigeria
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           check-latest: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             node_modules

--- a/.github/workflows/validate-mock-provider.yaml
+++ b/.github/workflows/validate-mock-provider.yaml
@@ -6,10 +6,9 @@ on:
   # Cron schedule for every weekday at 4 PM GMT
   schedule:
     - cron: '0 16 * * 1-5'
-  # Whenever this file is updated
   push:
-    paths:
-      - '.github/workflows/validate-mock-provider.yml'
+    branches:
+      - 'satish/validate-job'
 
 jobs:
   validate:

--- a/.github/workflows/validate-mock-provider.yaml
+++ b/.github/workflows/validate-mock-provider.yaml
@@ -6,9 +6,6 @@ on:
   # Cron schedule for every weekday at 4 PM GMT
   schedule:
     - cron: '0 16 * * 1-5'
-  push:
-    branches:
-      - 'satish/validate-job'
 
 jobs:
   validate:

--- a/.github/workflows/validate-mock-provider.yaml
+++ b/.github/workflows/validate-mock-provider.yaml
@@ -6,6 +6,9 @@ on:
   # Cron schedule for every weekday at 4 PM GMT
   schedule:
     - cron: '0 16 * * 1-5'
+  push:
+    branches:
+      - 'satish/validate-job'
 
 jobs:
   validate:


### PR DESCRIPTION
For [ACT-479](https://linear.app/valora/issue/ACT-479/alerts-for-when-fiatconnectvalidate-and-mock-provider-fail).
Test runs: https://github.com/fiatconnect/validate/actions/workflows/validate-mock-provider.yaml
Failure alerts: https://valora-app.slack.com/archives/C02KBT0DAHJ/p1668722845482409