### PR TITLE
fix(config): make quote-in-mock and quote-out-mock optional, but require one

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -41,15 +41,14 @@ export const config = yargs
   .option('quote-in-mock', {
     description:
       'Mock data to use for a transfer in quote that should be offered',
-    demandOption: true,
+    demandOption: false,
     example: 'quoteInNigeriaCUSD',
     choices: Object.keys(MOCK_QUOTE),
-    default: '',
   })
   .option('quote-out-mock', {
     description:
       'Mock data to use for a transfer out quote that should be offered',
-    demandOption: true,
+    demandOption: false,
     example: 'quoteOutNigeriaCUSD',
     choices: Object.keys(MOCK_QUOTE),
   })
@@ -64,6 +63,14 @@ export const config = yargs
     demandOption: true,
     example: 'personalDataAndDocumentsNigeria',
     choices: Object.keys(MOCK_KYC),
+  })
+  .check(({ quoteInMock, quoteOutMock }) => {
+    if (!quoteOutMock && !quoteInMock) {
+      throw new Error(
+        'Must specify at least one of quote-in-mock or quote-out-mock',
+      )
+    }
+    return true
   })
   .help()
   .parseSync()

--- a/validations/quote.test.ts
+++ b/validations/quote.test.ts
@@ -7,7 +7,10 @@ import { config } from '../src/config'
 import { checkResponseSchema } from '../src/check-response-schema'
 import { MOCK_QUOTE } from '../src/mock-data/quote'
 import { ethers } from 'ethers'
-import { quoteResponseSchema } from '@fiatconnect/fiatconnect-types'
+import {
+  QuoteRequestBody,
+  quoteResponseSchema,
+} from '@fiatconnect/fiatconnect-types'
 
 const apiDefinitionsPath = path.join(config.openapiSpec)
 use(chaiPlugin({ apiDefinitionsPath }))
@@ -17,33 +20,48 @@ const headers: AxiosRequestHeaders = config.clientApiKey
   : {}
 
 describe('/quote', () => {
-  describe('/out', () => {
-    const wallet = ethers.Wallet.createRandom()
-    const quoteParams = {
-      ...MOCK_QUOTE[config.quoteOutMock],
-      address: wallet.address,
-    }
-    it('gives quote with quoteId when it should', async () => {
+  const { quoteOutMock, quoteInMock } = config
+  const wallet = ethers.Wallet.createRandom()
+  const cases: { quoteParams: QuoteRequestBody; quoteType: 'in' | 'out' }[] = []
+  if (quoteInMock) {
+    cases.push({
+      quoteParams: { ...MOCK_QUOTE[quoteInMock], address: wallet.address },
+      quoteType: 'in',
+    })
+  }
+  if (quoteOutMock) {
+    cases.push({
+      quoteParams: { ...MOCK_QUOTE[quoteOutMock], address: wallet.address },
+      quoteType: 'out',
+    })
+  }
+  it.each(cases)(
+    'gives quote with quoteId for transfer $quoteType',
+    async ({ quoteParams, quoteType }) => {
       const client = axios.create({
         baseURL: config.baseUrl,
         validateStatus: () => true,
         headers,
       })
-      const response = await client.post(`/quote/out`, quoteParams)
+      const response = await client.post(`/quote/${quoteType}`, quoteParams)
       expect(response).to.have.status(200)
       expect(response.data.quote.quoteId).not.to.be.equal('')
       checkResponseSchema(response, quoteResponseSchema)
-    })
-    it('Doesnt support quotes for unreasonably large transfer out', async () => {
+    },
+  )
+
+  it.each(cases)(
+    'Doesnt support quotes for unreasonably large transfer $quoteType',
+    async ({ quoteParams, quoteType }) => {
       const client = axios.create({
         baseURL: config.baseUrl,
         validateStatus: () => true,
         headers,
       })
       quoteParams.cryptoAmount = Number.MAX_VALUE.toString()
-      const response = await client.post(`/quote/out`, quoteParams)
+      const response = await client.post(`/quote/${quoteType}`, quoteParams)
       expect(response).to.have.status(400)
       expect(response.data.error).to.be.equal('CryptoAmountTooHigh')
-    })
-  })
+    },
+  )
 })

--- a/validations/transfer.test.ts
+++ b/validations/transfer.test.ts
@@ -27,7 +27,8 @@ describe('/transfer', () => {
   const mockKYCInfo: AddKycParams<KycSchema> =
     MOCK_KYC[config.kycMock as keyof typeof MOCK_KYC]
 
-  if (config.quoteInMock) {
+  const { quoteInMock, quoteOutMock } = config
+  if (quoteInMock) {
     describe('/in', () => {
       const wallet = ethers.Wallet.createRandom()
 
@@ -42,7 +43,7 @@ describe('/transfer', () => {
       )
 
       const quoteInParams = {
-        ...MOCK_QUOTE[config.quoteInMock],
+        ...MOCK_QUOTE[quoteInMock],
         address: wallet.address,
       }
 
@@ -103,7 +104,7 @@ describe('/transfer', () => {
     })
   }
 
-  if (config.quoteOutMock) {
+  if (quoteOutMock) {
     describe('/out', () => {
       const wallet = ethers.Wallet.createRandom()
 
@@ -118,7 +119,7 @@ describe('/transfer', () => {
       )
 
       const quoteOutParams = {
-        ...MOCK_QUOTE[config.quoteOutMock],
+        ...MOCK_QUOTE[quoteOutMock],
         address: wallet.address,
       }
 

--- a/validations/webhook.test.ts
+++ b/validations/webhook.test.ts
@@ -120,8 +120,8 @@ describe('webhooks', () => {
       (message: string) => wallet.signMessage(message),
     )
   })
-
-  if (config.quoteInMock) {
+  const { quoteInMock, quoteOutMock } = config
+  if (quoteInMock) {
     describe('transfer in', () => {
       it('sends webhooks for transfer in requests', async () => {
         expect(
@@ -130,7 +130,7 @@ describe('webhooks', () => {
         ).to.be.true
         // Setup
         const quoteInParams = {
-          ...MOCK_QUOTE[config.quoteInMock],
+          ...MOCK_QUOTE[quoteInMock],
           address: wallet.address,
         }
         const loginResult = await fiatConnectClient.login()
@@ -188,7 +188,7 @@ describe('webhooks', () => {
       })
     })
   }
-  if (config.quoteOutMock) {
+  if (quoteOutMock) {
     describe('transfer out', () => {
       it('sends webhooks for transfer out requests', async () => {
         expect(
@@ -197,7 +197,7 @@ describe('webhooks', () => {
         ).to.be.true
         // Setup
         const quoteOutParams = {
-          ...MOCK_QUOTE[config.quoteOutMock],
+          ...MOCK_QUOTE[quoteOutMock],
           address: wallet.address,
         }
         const loginResult = await fiatConnectClient.login()


### PR DESCRIPTION
validation tests failed against our mock provider because we started requiring quote-in-mock to not just be an emptystring. this requires you to define at least one of the mock quote types. 