### PR TITLE
feat(schema-validation): allow arbitrary path prefixes to be ignored 

### DIFF
--- a/src/check-response-schema.ts
+++ b/src/check-response-schema.ts
@@ -16,19 +16,20 @@ use(chaiPlugin({ apiDefinitionsPath }))
  * Ignores /vX prefix
  *
  * @param response
+ * @param pathPrefix
  * @param schema: If provided, runs additional check using a zod schema. The spec should be the
  *  source of truth, but sometimes zod schemas allow for more granular checks-- for instance, with enum values.
  */
 export function checkResponseSchema<T extends AnyZodObject>(
   response: AxiosResponse,
+  pathPrefix: string,
   schema?: T,
 ) {
   // check response against FiatConnect spec
-  const versionPrefixMatch = response.request.path.match(/^\/v([0-9]+)/)
-  if (versionPrefixMatch) {
-    // removes /vX prefix, total hack to get api schema matcher to work
+  if (pathPrefix !== '' && response.request.path.indexOf(pathPrefix) === 0) {
+    // removes path prefix like /v1, total hack to get api schema matcher to work
     response.request.path = response.request.path.slice(
-      versionPrefixMatch[0].length,
+      pathPrefix.length,
     )
   }
   expect(response).to.matchApiSchema()

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,12 @@ export const config = yargs
     type: 'string',
     demandOption: true,
   })
+  .option('path-prefix', {
+    description: 'Any prefix to the FiatConnect endpoints. This is used to help chai match request paths against the OpenAPI spec, which only recognizes paths like `/auth/login`, not `/v1/auth/login`',
+    type: 'string',
+    default: '',
+    example: '/v1'
+  })
   .option('openapi-spec', {
     description: 'OpenAPI 2.0 specification file to test against',
     type: 'string',

--- a/validations/auth.test.ts
+++ b/validations/auth.test.ts
@@ -58,7 +58,7 @@ describe('/auth/login', () => {
       signature,
     })
     expect(response).to.have.status(200)
-    checkResponseSchema(response)
+    checkResponseSchema(response, config.pathPrefix)
 
     const response2 = await client.post('/auth/login', {
       message,

--- a/validations/clock.test.ts
+++ b/validations/clock.test.ts
@@ -18,7 +18,7 @@ describe('/clock', () => {
     })
     const response = await client.get(`/clock`)
     expect(response).to.have.status(200)
-    checkResponseSchema(response, clockResponseSchema)
+    checkResponseSchema(response, config.pathPrefix, clockResponseSchema)
     const serverTimeStr = response.data?.time
     expect(!!serverTimeStr).to.be.true
     const serverTime = new Date(serverTimeStr)

--- a/validations/quote.test.ts
+++ b/validations/quote.test.ts
@@ -32,7 +32,7 @@ describe('/quote', () => {
       const response = await client.post(`/quote/out`, quoteParams)
       expect(response).to.have.status(200)
       expect(response.data.quote.quoteId).not.to.be.equal('')
-      checkResponseSchema(response, quoteResponseSchema)
+      checkResponseSchema(response, config.pathPrefix, quoteResponseSchema)
     })
     it('Doesnt support quotes for unreasonably large transfer out', async () => {
       const client = axios.create({


### PR DESCRIPTION
for response schema validation against openapi spec