### PR TITLE
chore (types): dont destructure argv in yargs check

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -71,8 +71,8 @@ export const config = yargs
     example: 'personalDataAndDocumentsNigeria',
     choices: Object.keys(MOCK_KYC),
   })
-  .check(({ quoteInMock, quoteOutMock }) => {
-    if (!quoteOutMock && !quoteInMock) {
+  .check((argv) => {
+    if (!argv.quoteOutMock && !argv.quoteInMock) {
       throw new Error(
         'Must specify at least one of quote-in-mock or quote-out-mock',
       )


### PR DESCRIPTION
my IDE was showing this error for the `check` callback as it was previously written:
```
Argument type ({quoteInMock, quoteOutMock}: {quoteInMock: any, quoteOutMock: any}) => true is not assignable to parameter type (argv: Arguments<{} & {[key in "test-private-key"]: InferredOptionType<{default: string, description: string, type: "string"}>} & Alias<{default: string, description: string, type: "string"}> & {[key in "base-url"]: InferredOptionType<{demandOption: boolean, description: string, type: "string"}>} & Alias<{demandOption: boolean, description: string, type: "string"}> & {[key in "path-prefix"]: InferredOptionType<{default: string, description: string, type: "string", example: string}>} & Alias<{default: string, description: string, type: "string", example: string}> & {[key in "openapi-spec"]: InferredOptionType<{coerce: (arg: any) => string, demandOption: boolean, description: string, type: "string"}>} & Alias<{coerce: (arg: any) => string, demandOption: boolean, description: string, type: "string"}> & {[key in "client-api-key"]: InferredOptionType<{demandOption: boolean, description: string, type: "string"}>} & Alias<{demandOption: boolean, description: string, type: "string"}> & ...>, aliases: {[p: string]: string}) => any 
```

Strangely, no build errors result, and this also does not cause any runtime errors when running tests. I'm pushing it anyway in case it improves devX for others too.