### PR TITLE
fix: use correct quote options on workflow

### DIFF
--- a/.github/workflows/validate-mock-provider.yaml
+++ b/.github/workflows/validate-mock-provider.yaml
@@ -34,7 +34,7 @@ jobs:
           CLIENT_API_KEY: ${{ secrets.MOCK_PROVIDER_API_KEY }}
           PROVIDER_ID: ${{ secrets.MOCK_PROVIDER_ID }}
           OPENAPI_SPEC: specification-swagger.yaml
-          QUOTE_OUT_MOCK: quoteOutNigeriaCUSD
+          QUOTE_OUT_MOCK: quoteNigeriaCUSD
           FIAT_ACCOUNT_MOCK: accountNumberNigeria
           KYC_MOCK: personalDataAndDocumentsNigeria
       - uses: ravsamhq/notify-slack-action@v2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Setup a config file (remember to customize):
 ```
 echo BASE_URL=https://some.api.fiatconnect.org > .env
 echo OPENAPI_SPEC=/path/to/swagger.yaml >> .env
-echo QUOTE_OUT_MOCK=quoteOutNigeriaCUSD
+echo QUOTE_OUT_MOCK=quoteNigeriaCUSD
 echo FIAT_ACCOUNT_MOCK=accountNumberNigeria
 echo KYC_MOCK=personalDataAndDocumentsNigeria
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,7 @@ export const config = yargs
     description:
       'Mock data to use for a transfer in quote that should be offered',
     demandOption: false,
-    example: 'quoteInNigeriaCUSD',
+    example: 'quoteNigeriaCUSD',
     choices: Object.keys(MOCK_QUOTE),
   })
   .option('ensure-user-init-transfer-in', {
@@ -62,7 +62,7 @@ export const config = yargs
     description:
       'Mock data to use for a transfer out quote that should be offered',
     demandOption: false,
-    example: 'quoteOutNigeriaCUSD',
+    example: 'quoteNigeriaCUSD',
     choices: Object.keys(MOCK_QUOTE),
   })
   .option('fiat-account-mock', {


### PR DESCRIPTION
Fixes failing mock-provider test, which was due to using an old quote mock name. This PR updates it to use the new names and also the examples.