### PR TITLE
fix: Allow any version of node 16 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Valora Inc",
   "license": "MIT",
   "engines": {
-    "node": "^16"
+    "node": ">=16"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
With the current package.json I got the following on `yarn`:

```sh
[1/5] 🔍  Validating package.json...
error validate@0.0.1: The engine "node" is incompatible with this module. Expected version "^16". Got "22.3.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

[sist](https://github.com/dawsonbotsford/sist) output:

### node
`node --version`: v22.3.0
`yarn -v`: 1.22.22