### PR TITLE
ci: Disable scheduled trigger in validate-mock-provider

### DIFF
--- a/.github/workflows/validate-mock-provider.yaml
+++ b/.github/workflows/validate-mock-provider.yaml
@@ -4,8 +4,8 @@ on:
   # Manual trigger
   workflow_dispatch:
   # Cron schedule for every weekday at 4 PM GMT
-  schedule:
-    - cron: '0 16 * * 1-5'
+  # schedule:
+  #   - cron: '0 16 * * 1-5'
 
 jobs:
   validate:


### PR DESCRIPTION
There's no mock provider any longer (this was removed from celo-mobile-alfajores)